### PR TITLE
Remove SDL2_image

### DIFF
--- a/.github/workflows/build-libs.yml
+++ b/.github/workflows/build-libs.yml
@@ -89,8 +89,6 @@ jobs:
       run: |
         # SDL2 dependencies
         brew install ninja
-        # SDL2_image dependencies (https://github.com/libsdl-org/SDL_image/blob/0b79762f0a7da2aa05f0673d367994f7eb9ad812/.github/workflows/main.yml#L65-L81)
-        brew install autoconf automake jpeg-turbo libavif libpng libtiff nasm webp
 
     - name: Install dependencies (Linux)
       if: ${{ matrix.platform == 'linux' }}
@@ -104,8 +102,6 @@ jobs:
             libxrandr-dev libxcursor-dev libxfixes-dev libxi-dev libxss-dev \
             libxkbcommon-dev libdrm-dev libgbm-dev libgl1-mesa-dev libgles2-mesa-dev \
             libegl1-mesa-dev libdbus-1-dev libibus-1.0-dev libudev-dev fcitx-libs-dev
-        # SDL2_image dependencies (https://github.com/libsdl-org/SDL_image/blob/0b79762f0a7da2aa05f0673d367994f7eb9ad812/.github/workflows/main.yml#L82-L100)
-        sudo apt-get install autoconf automake libavif-dev libjpeg-dev libtiff-dev libtool libwebp-dev nasm zlib1g-dev
 
     # SDL2
     - name: Configure SDL2
@@ -140,37 +136,6 @@ jobs:
     - name: Export SDL2 library path (Linux)
       if: ${{ matrix.platform == 'linux' }}
       run: echo "SDL2_LIB=${{ env.SDL2_DIR }}/lib/libSDL2-2.0.so" >> $GITHUB_ENV
-
-    # SDL2_image
-    - name: Configure SDL2_image
-      working-directory: source/SDL2_image
-      run: |
-        export CMAKE_CONFIGURATION_TYPES=${{ env.BUILD_TYPE }}
-        # JPEG-XL is disabled, because it's causing issues on macOS
-        cmake -B build -G Ninja \
-          -DSDL2IMAGE_SAMPLES=ON \
-          -DSDL2IMAGE_AVIF=ON \
-          -DSDL2IMAGE_JXL=OFF \
-          -DSDL2IMAGE_TIF=ON \
-          -DSDL2IMAGE_WEBP=ON \
-          -DSDL2IMAGE_VENDORED=ON \
-          -DSDL2IMAGE_DEBUG_POSTFIX="" \
-          -DCMAKE_MSVC_RUNTIME_LIBRARY="MultiThreaded$<$<CONFIG:Debug>:Debug>" \
-          -DCMAKE_INSTALL_PREFIX=cmake_prefix \
-          -DCMAKE_RUNTIME_OUTPUT_DIRECTORY=$PWD/build \
-          -DCMAKE_LIBRARY_OUTPUT_DIRECTORY=$PWD/build \
-          -DCMAKE_BUILD_TYPE=${{ env.BUILD_TYPE }}
-
-    - name: Build SDL2_image
-      working-directory: source/SDL2_image
-      run: cmake --build build --config ${{ env.BUILD_TYPE }} --verbose --parallel
-
-    - name: Install SDL2_image
-      working-directory: source/SDL2_image
-      run: |
-        set -eu
-        cmake --install build --config ${{ env.BUILD_TYPE }}
-        echo "SDL2_image_DIR=$(pwd)/cmake_prefix" >> $GITHUB_ENV
 
     # FNA3D + FAudio
     - name: Update FNA3D + FAudio CMake version (Windows)
@@ -269,7 +234,6 @@ jobs:
       if: ${{ matrix.platform == 'windows' }}
       run: |
         cp ${{ env.SDL2_DIR }}/bin/SDL2.dll SDL2.dll
-        cp ${{ env.SDL2_image_DIR }}/bin/SDL2_image.dll SDL2_image.dll
         cp source/FNA/lib/FAudio/build/FAudio.dll FAudio.dll
         cp source/FNA/lib/FNA3D/build/FNA3D.dll FNA3D.dll
         cp source/FNA/lib/Theorafile/libtheorafile.dll libtheorafile.dll
@@ -278,7 +242,6 @@ jobs:
       if: ${{ matrix.platform == 'macos' }}
       run: |
         cp ${{ env.SDL2_DIR }}/lib/libSDL2-2.0.0.dylib libSDL2-2.0.0.dylib
-        cp ${{ env.SDL2_image_DIR }}/lib/libSDL2_image-2.0.dylib libSDL2_image-2.0.0.dylib
         cp source/FNA/lib/FAudio/build/libFAudio.0.dylib libFAudio.0.dylib
         cp source/FNA/lib/FNA3D/build/libFNA3D.0.dylib libFNA3D.0.dylib
         cp source/FNA/lib/Theorafile/libtheorafile.dylib libtheorafile.dylib
@@ -291,7 +254,6 @@ jobs:
         cp source/FNA/bin/${{ env.BUILD_TYPE }}/net7.0/FNA.dll FNA.dll
         cp source/FNA/bin/${{ env.BUILD_TYPE }}/net7.0/FNA.pdb FNA.pdb
         cp ${{ env.SDL2_DIR }}/lib/libSDL2-2.0.so.0 libSDL2-2.0.so.0
-        cp ${{ env.SDL2_image_DIR }}/lib/libSDL2_image-2.0.so.0 libSDL2_image-2.0.so.0
         cp source/FNA/lib/FAudio/build/libFAudio.so.0 libFAudio.so.0
         cp source/FNA/lib/FNA3D/build/libFNA3D.so.0 libFNA3D.so.0
         cp source/FNA/lib/Theorafile/libtheorafile.so libtheorafile.so
@@ -303,7 +265,6 @@ jobs:
         name: fnalibs-windows-${{ matrix.msys2_env }}
         path: |
           SDL2.dll
-          SDL2_image.dll
           FAudio.dll
           FNA3D.dll
           libtheorafile.dll
@@ -315,7 +276,6 @@ jobs:
         name: fnalibs-macos-x86_64
         path: |
           libSDL2-2.0.0.dylib
-          libSDL2_image-2.0.0.dylib
           libFAudio.0.dylib
           libFNA3D.0.dylib
           libtheorafile.dylib
@@ -331,7 +291,6 @@ jobs:
           FNA.dll
           FNA.pdb
           libSDL2-2.0.so.0
-          libSDL2_image-2.0.so.0
           libFAudio.so.0
           libFNA3D.so.0
           libtheorafile.so
@@ -485,7 +444,6 @@ jobs:
 
           # Linux x64
           cp ../binaries/fnalibs-linux-x86_64/libSDL2-2.0.so.0 lib-vanilla/lib64
-          cp ../binaries/fnalibs-linux-x86_64/libSDL2_image-2.0.so.0 lib-vanilla/lib64
           cp ../binaries/fnalibs-linux-x86_64/libFAudio.so.0 lib-vanilla/lib64
           cp ../binaries/fnalibs-linux-x86_64/libFNA3D.so.0 lib-vanilla/lib64
           cp ../binaries/fnalibs-linux-x86_64/libtheorafile.so lib-vanilla/lib64

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,9 +4,6 @@
 [submodule "SDL2"]
 	path = source/SDL2
 	url = https://github.com/libsdl-org/SDL/
-[submodule "SDL2_image"]
-	path = source/SDL2_image
-	url = https://github.com/libsdl-org/SDL_image/
 [submodule "Piton"]
 	path = source/Piton
 	url = https://github.com/EverestAPI/Piton

--- a/.gitmodules
+++ b/.gitmodules
@@ -6,7 +6,7 @@
 	url = https://github.com/libsdl-org/SDL/
 [submodule "Piton"]
 	path = source/Piton
-	url = https://github.com/EverestAPI/Piton
+	url = https://github.com/Popax21/Piton
 [submodule "source/MoltenVK"]
 	path = source/MoltenVK
 	url = https://github.com/KhronosGroup/MoltenVK

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ These libraries are open source and are built in CI.
 - Theorafile [48d74af](https://github.com/FNA-XNA/Theorafile/tree/48d74afcbf838fe95ca56cec142efae07bb56f65)
 - MoltenVK `1.2.11`
 - Vulkan Loader `1.3.296`
-- Piton [21c7868](https://github.com/EverestAPI/Piton/tree/21c7868d06007f0c5e7d9030a0109fe892df1bf3)
+- Piton [21c7868](https://github.com/Popax21/Piton/tree/21c7868d06007f0c5e7d9030a0109fe892df1bf3)
 
 ### Closed-Source Libraries
 These libraries are closed source and cannot be _built_ in CI.  
@@ -22,4 +22,4 @@ Some are not accessible without an account, and therefore need to be vendored as
 
 - DiscordGameSDK `3.2.1` (downloaded: https://dl-game-sdk.discordapp.net/3.2.1/discord_game_sdk.zip)
 - FMOD Engine `1.10.14` (vendored: [Download (Requires account)](https://www.fmod.com/download#fmodengine), [License](https://github.com/EverestAPI/Everest-libs/blob/main/binaries/fmod/EULA-FMOD.txt))
-- Steamworks SDK `1.40` (with Steamworks.NET `10.0.0`) (vendored: [Download (Offical, Requires account)](https://partner.steamgames.com/downloads/list), [Download (via Steamworks.NET)](https://github.com/rlabrecque/Steamworks.NET/releases/tag/10.0.0))
+- Steamworks SDK `1.40` (with Steamworks.NET `10.0.0`) (vendored: [Download (Official, Requires account)](https://partner.steamgames.com/downloads/list), [Download (via Steamworks.NET)](https://github.com/rlabrecque/Steamworks.NET/releases/tag/10.0.0))

--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ This repository contains the latest libraries needed for Everest in answer to [t
 These libraries are open source and are built in CI.  
 
 - SDL2 `2.28.5`
-- SDL2_image `2.8.2`
 - FNA `24.01`
 - FNA3D `24.01`
 - FAudio `24.01`


### PR DESCRIPTION
It was never used in everest stable versions anyway, also fixed some typos.